### PR TITLE
Made FIFO methods more flexible

### DIFF
--- a/include/marvin/containers/marvin_FIFO.h
+++ b/include/marvin/containers/marvin_FIFO.h
@@ -79,6 +79,7 @@ namespace marvin::containers::fifos {
             Tries to emplace an element into the back of the queue. If the queue is full, has no effect.
             Never allocates.
             \param x The value to push into the queue.
+            \return Whether the value was pushed into the queue.
         */
         bool tryPush(T&& x) noexcept {
             return m_queue.try_enqueue(std::move(x));
@@ -88,6 +89,7 @@ namespace marvin::containers::fifos {
             Tries to emplace an element into the back of the queue. If the queue is full, has no effect.
             Never allocates.
             \param x The value to push into the queue. Must be trivially copyable.
+            \return Whether the value was pushed into the queue.
         */
         bool tryPush(const T& x) noexcept(std::is_nothrow_copy_constructible_v<T>) requires std::is_trivially_copyable_v<T> {
             return m_queue.try_enqueue(x);
@@ -95,8 +97,9 @@ namespace marvin::containers::fifos {
 
         /**
             Tries to construct an element in-place into the back of the queue. If the queue is full, has no effect.
-            Never allocates. `T` must by trivially constructible from the types in `Args`.
+            Never allocates. `T` must by trivially constructible from the types in `Args`. Can only be used on an SPSC queue.
             \param args The arguments used to construct the element in-place.
+            \return Whether the value was pushed into the queue.
         */
         template<typename... Args> requires(std::is_trivially_constructible_v<T, Args...> && QueueType == Type::SPSC)
         bool tryEmplace(Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args...>) {

--- a/include/marvin/containers/marvin_FIFO.h
+++ b/include/marvin/containers/marvin_FIFO.h
@@ -80,8 +80,27 @@ namespace marvin::containers::fifos {
             Never allocates.
             \param x The value to push into the queue.
         */
-        void tryPush(T&& x) noexcept {
-            [[maybe_unused]] const auto res = m_queue.try_enqueue(std::move(x));
+        bool tryPush(T&& x) noexcept {
+            return m_queue.try_enqueue(std::move(x));
+        }
+
+        /**
+            Tries to emplace an element into the back of the queue. If the queue is full, has no effect.
+            Never allocates.
+            \param x The value to push into the queue. Must be trivially copyable.
+        */
+        bool tryPush(const T& x) noexcept(std::is_nothrow_copy_constructible_v<T>) requires std::is_trivially_copyable_v<T> {
+            return m_queue.try_enqueue(x);
+        }
+
+        /**
+            Tries to construct an element in-place into the back of the queue. If the queue is full, has no effect.
+            Never allocates. `T` must by trivially constructible from the types in `Args`.
+            \param args The arguments used to construct the element in-place.
+        */
+        template<typename... Args> requires(std::is_trivially_constructible_v<T, Args...> && QueueType == Type::SPSC)
+        bool tryEmplace(Args&&... args) noexcept(std::is_nothrow_constructible_v<T, Args...>) {
+            return m_queue.try_emplace(std::forward<Args>(args)...);
         }
 
         /**


### PR DESCRIPTION
1. Added a `tryPush(const T&)` overload to the FIFO. The rationale is that if `T` is a trivially copyable type, moving it has no effect and will produce a clang-tidy warning so the user should not be forced to use the rvalue reference overload. The method is constrained to only be available if `T` is trivially copyable to ensure no allocation takes place.
2. Added a `tryEmplace(Args&&...)` method to the FIFO. This uses the `ReaderWriterQueue<T>`'s `try_emplace(Args&&...)` method, so is only available for SPSC queues. It is required that `T` is trivially constructible from `Args` to ensure no allocation takes place.
3. Made both `tryPush()` overloads and the new `tryEmplace()` method return the `bool` result from the inner method call. I don't see a reason against this, but I haven't marked them `[[nodiscard]]` - let me know your thoughts on this one.